### PR TITLE
Added third storyblok slug resolver function to allow richtext links …

### DIFF
--- a/projects/geometricpanda/ng-storyblok/components/richtext/rich-text.directive.ts
+++ b/projects/geometricpanda/ng-storyblok/components/richtext/rich-text.directive.ts
@@ -57,7 +57,7 @@ enum MarkType {
 export class RichTextRendererDirective {
     el = inject(ElementRef);
     renderer = inject(Renderer2);
-    slugToUrl = inject(NG_STORYBLOK_SLUG_REWRITE, { optional: true })?.toUrl;
+    slugToUrl = inject(NG_STORYBLOK_SLUG_REWRITE, { optional: true })?.toRichtextUrl;
 
     storyblokRichText = input.required<ISbRichtext>();
 

--- a/projects/geometricpanda/ng-storyblok/config/with-slug-rewrite.config.ts
+++ b/projects/geometricpanda/ng-storyblok/config/with-slug-rewrite.config.ts
@@ -1,13 +1,18 @@
 import { NG_STORYBLOK_SLUG_REWRITE, RewriteFn, SlugRewrite } from '@geometricpanda/ng-storyblok/tokens';
 import { NgStoryblokFeatureKind, NgStoryblokSlugRewriteFeature, createNgSbFeature } from './_features.config';
 
-export function withSlugRewrite(toStory: RewriteFn, toUrl: RewriteFn): NgStoryblokSlugRewriteFeature {
+export function withSlugRewrite(
+    toStory: RewriteFn,
+    toUrl: RewriteFn,
+    toRichtextUrl: RewriteFn, // Specific handler for richtext links that don't use the Angular router
+): NgStoryblokSlugRewriteFeature {
     return createNgSbFeature(NgStoryblokFeatureKind.SlugRewriteFeature, [
         {
             provide: NG_STORYBLOK_SLUG_REWRITE,
             useValue: <SlugRewrite>{
                 toStory,
                 toUrl,
+                toRichtextUrl,
             },
         },
     ]);

--- a/projects/geometricpanda/ng-storyblok/tokens/slug-rewrite.token.ts
+++ b/projects/geometricpanda/ng-storyblok/tokens/slug-rewrite.token.ts
@@ -5,6 +5,7 @@ export type RewriteFn = (slug: string) => string;
 export interface SlugRewrite {
     toStory: RewriteFn;
     toUrl: RewriteFn;
+    toRichtextUrl: RewriteFn;
 }
 
 export const NG_STORYBLOK_SLUG_REWRITE = new InjectionToken<SlugRewrite>('NG_STORYBLOK_SLUG_REWRITE');

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -81,6 +81,7 @@ export const appConfig: ApplicationConfig = {
             withSlugRewrite(
                 (slug) => slug || 'home',
                 (slug) => (slug === 'home' ? '/' : slug),
+                (slug) => (slug === 'home' ? '/' : slug),
             ),
             withBloks({
                 [BLOK.PAGE]: () => import('./cms-components/page-blok'),


### PR DESCRIPTION
…to be handled differently

Due to the Richtext links not being filtered through the Angular router, unlike other links, there's a discrepancy when consuming applications that have a baseHref that isn't '/'. This change allows richtext slugs to be resolved differently, accounting for this discrepancy.